### PR TITLE
EditorCore: Fix exception messages

### DIFF
--- a/EditorCore/WindWaker/Loaders/MapLoader.cs
+++ b/EditorCore/WindWaker/Loaders/MapLoader.cs
@@ -13,7 +13,7 @@ namespace WEditor.WindWaker.Loaders
         public Map CreateFromDirectory(WWorld world, string folderPath)
         {
             if (world == null)
-                throw new ArgumentNullException("No world to load map into specified.");
+                throw new ArgumentNullException("world", "No world to load map into specified.");
 
             if (string.IsNullOrEmpty(folderPath))
                 throw new ArgumentException("folderPath is null or empty!");

--- a/EditorCore/WindWaker/Loaders/SceneLoader.cs
+++ b/EditorCore/WindWaker/Loaders/SceneLoader.cs
@@ -11,9 +11,9 @@ namespace WEditor.WindWaker.Loaders
         public T LoadFromArchive<T>(WWorld world, ZArchive archive) where T : Scene, new()
         {
             if (world == null)
-                throw new ArgumentNullException("world must not be null!");
+                throw new ArgumentNullException("world");
             if (archive == null)
-                throw new ArgumentNullException("archive must not be null!");
+                throw new ArgumentNullException("archive");
 
             T scene = new T();
 


### PR DESCRIPTION
The name of the parameter is the first argument for ArgumentExceptions.

Removed the messages that indicate [x] can't be null, since the parameter name alone coupled with the exception type indicate this.
