### PR TITLE
Fix Culture Problems

### DIFF
--- a/WindEditor/View/MainWindow.xaml.cs
+++ b/WindEditor/View/MainWindow.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using OpenTK;
 using OpenTK.Graphics;
 using System;
+using System.Globalization;
+using System.Threading;
 using System.Windows;
 using System.Windows.Input;
 using WEditor.WindWaker.Entities;
@@ -23,6 +25,9 @@ namespace WindEditor
 
         public MainWindow()
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             m_viewModel = new MainWindowViewModel();
             InitializeComponent();
             DataContext = m_viewModel;


### PR DESCRIPTION
By not specifying the Culture, a lot of formatting and parsing is
completely different in certain cultures, causing a lot of things to
break. The Shader Generator generates wrong shaders in Germany for
example, as we Germans use a "," as the decimal point, instead of a ".".
This obviously causes a lot of problems with the floating point numbers,
as the shader compiler now tried to parse them as twice as many integer
parameters. Other issues like Decimal Numbers in the UI caused problems
too, so the safest solution is to just set the Culture globally to an
invariant Culture.
