### PR TITLE
Fix the Hint Path of OpenTK.Control

### DIFF
--- a/WindEditor/WindEditor.csproj
+++ b/WindEditor/WindEditor.csproj
@@ -64,7 +64,7 @@
       <HintPath>..\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK.GLControl">
-      <HintPath>..\..\..\Visual Studio 2015\Projects\TestEditorInterface\TestViewport\bin\Debug\OpenTK.GLControl.dll</HintPath>
+      <HintPath>..\OpenTK.GLControl.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
It tries to find it in some place that is not available on everyone's PC.
